### PR TITLE
Fix installation on OSX

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -7,7 +7,9 @@ install_mongo() {
   local platform=""
   local arch=""
   local tempdir=""
+  local tempfile=""
   local filename=""
+  local download_url=""
 
   [ "Linux" = "$(uname)" ] && platform="linux" || platform="osx"
   [ "x86_64" = "$(uname -m)" ] && arch="x86_64" || arch="i686"
@@ -17,11 +19,14 @@ install_mongo() {
   then
     filename="mongodb-linux-${arch}-${version}.tgz"
   else
-    filename="mongodb-osx-x86_64-${version}.tgz"
+    filename="mongodb-osx-ssl-x86_64-${version}.tgz"
   fi
 
-  curl -L "http://downloads.mongodb.org/${platform}/${filename}" -o "${tempdir}/${filename}"
-  tar zxf "${tempdir}/${filename}" -C $install_path --strip-components=1 || exit 1
+  tempfile="${tempdir}/${filename}"
+  download_url="https://fastdl.mongodb.org/${platform}/${filename}"
+
+  curl -L "${download_url}" -o "${tempfile}"
+  tar zxf "${tempfile}" -C $install_path --strip-components=1 || exit 1
 
   rm -rf "${tempdir}"
 }


### PR DESCRIPTION
The problem:
-------------
Install versions less than 4.x throws an error (`tar: Unrecognized archive format`). Reason: The download URL change and the filename of OSX versions received a `ssl`. e.g:

**Old URL:**
http://downloads.mongodb.org/osx/mongodb-osx-x86_64-4.0.5.tgz

**New URL:**
http://_**fastdl.mongodb.org**_/osx/mongodb-osx-_**ssl**_-x86_64-4.0.5.tgz

The solution:
-------------
Build the right download URL and filename for OSX installations.