### PR TITLE
Fix mktemp failure on macOS

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -13,7 +13,7 @@ install_mongo() {
 
   [ "Linux" = "$(uname)" ] && platform="linux" || platform="osx"
   [ "x86_64" = "$(uname -m)" ] && arch="x86_64" || arch="i686"
-  [ "linux" = "${platform}" ] && tempdir=$(mktemp -d asdf-mongodb.XXXX) || tempdir=$(mktemp -dt asdf-mongodb)
+  [ "linux" = "${platform}" ] && tempdir=$(mktemp -d asdf-mongodb.XXXX) || tempdir=$(mktemp -dt asdf-mongodb.XXXX)
 
   if [[ "linux" = "${platform}" ]]
   then


### PR DESCRIPTION
This patch fixes a failure installing the mongo on macOS caused by too few placeholders passed to mktemp:

```shell-script
mktemp: too few X's in template ‘asdf-mongodb’

Warning: Failed to create the file /mongodb-osx-ssl-x86_64-3.6.6.tgz:

Warning: Permission denied

curl: (23) Failed writing body (0 != 16384)
```