### PR TITLE
Update macOS download URL

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -19,7 +19,7 @@ install_mongo() {
   then
     filename="mongodb-linux-${arch}-${version}.tgz"
   else
-    filename="mongodb-osx-ssl-x86_64-${version}.tgz"
+    filename="mongodb-macos-x86_64-${version}.tgz"
   fi
 
   tempfile="${tempdir}/${filename}"


### PR DESCRIPTION
The format of the download URL for macOS tarballs has been partially updated to reflect the OS's name change from 'OS X' to 'macOS'.

<img width="748" alt="Screen Shot 2020-04-01 at 5 28 24 PM" src="https://user-images.githubusercontent.com/4433943/78188656-9da74180-743e-11ea-8b1b-09a6c3a35662.png">

Related: #8, #7 

Successful installation:

```
mongodb master % asdf install mongodb 4.2.2

+ install_mongo version 4.2.2 ~/.asdf/installs/mongodb/4.2.2
+ local install_type=version
+ local version=4.2.2
+ local install_path=~/.asdf/installs/mongodb/4.2.2
+ local platform=
+ local arch=
+ local tempdir=
+ local tempfile=
+ local filename=
+ local download_url=
++ uname
+ '[' Linux = Darwin ']'
+ platform=osx
++ uname -m
+ '[' x86_64 = x86_64 ']'
+ arch=x86_64
+ '[' linux = osx ']'
++ mktemp -dt asdf-mongodb.XXXX
+ tempdir=/var/folders/7c/nwp4zv3574n24s27qgxfxkrm0000gn/T/asdf-mongodb.YpRa
+ [[ linux = \o\s\x ]]
+ filename=mongodb-macos-x86_64-4.2.2.tgz
+ tempfile=/var/folders/7c/nwp4zv3574n24s27qgxfxkrm0000gn/T/asdf-mongodb.YpRa/mongodb-macos-x86_64-4.2.2.tgz
+ download_url=https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.2.2.tgz
+ curl -L https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.2.2.tgz -o /var/folders/7c/nwp4zv3574n24s27qgxfxkrm0000gn/T/asdf-mongodb.YpRa/mongodb-macos-x86_64-4.2.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- -  0  104M    0     0    0     0      0      0 --:--:-- --:--:-- - 10  104M   10 11.2M    0     0  9422k      0  0:00:11  0:00:01   25  104M   25 26.2M    0     0  11.8M      0  0:00:08  0:00:02   37  104M   37 39.5M    0     0  12.3M      0  0:00:08  0:00:03   49  104M   49 51.4M    0     0  12.1M      0  0:00:08  0:00:04   57  104M   57 59.8M    0     0  11.4M      0  0:00:09  0:00:05   69  104M   69 72.6M    0     0  11.6M      0  0:00:08  0:00:06   79  104M   79 82.6M    0     0  11.4M      0  0:00:09  0:00:07   89  104M   89 92.9M    0     0  11.2M      0  0:00:09  0:00:08   99  104M   99  103M    0     0  11.2M      0  0:00:09  0:00:09 -100  104M  100  104M    0     0  11.2M      0  0:00:09  0:00:09 --:--:-- 10.9M
+ tar zxf /var/folders/7c/nwp4zv3574n24s27qgxfxkrm0000gn/T/asdf-mongodb.YpRa/mongodb-macos-x86_64-4.2.2.tgz -C /Users/jmromer/.asdf/installs/mongodb/4.2.2 --strip-components=1
+ rm -rf /var/folders/7c/nwp4zv3574n24s27qgxfxkrm0000gn/T/asdf-mongodb.YpRa

mongodb master % asdf list mongodb
  2.4.0
  4.2.2
  4.2.3
```

cc @sylph01 