### PR TITLE
fix URL template to linux archive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: asdf plugin-test mongodb https://github.com/sylph01/asdf-mongodb.git
+script: asdf plugin-test mongodb https://github.com/joshburnsxyz/asdf-mongodb.git
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh

--- a/bin/install
+++ b/bin/install
@@ -17,7 +17,7 @@ install_mongo() {
 
   if [[ "linux" = "${platform}" ]]
   then
-    filename="mongodb-linux-${arch}-${version}.tgz"
+    filename="mongodb-linux-${arch}-ubuntu2004-${version}.tgz"
   else
     filename="mongodb-macos-x86_64-${version}.tgz"
   fi


### PR DESCRIPTION
On linux using this plugin results in a message saying the `stdin is not in gzip format`. This is caused by an incorrect URL causing the fastdl API to throw an error. This patch simply fixes the URL template to look for the source archive under the correct name. This patch has been tested on my own machine and successfully installed _mongodb 5.0.1_. 

__Closes the following issues__

- #12
- #10
- #8 
- #7
- #5